### PR TITLE
Release v2.4.0 + new build system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM fedora:latest
 WORKDIR /root
 CMD ./build.sh
 
-RUN dnf install -y 'dnf-command(builddep)' rpm-build rpm-sign rpmlint gpg pinentry
+RUN dnf install -y 'dnf-command(builddep)' rpm-build rpm-sign rpmlint gpg pinentry pkg-config
+
+# These dependencies will be requested by builddep anyway (listed in SPECS/libcriterion.spec).
+# Installing binaries here allow a better use of docker layer caching.
+RUN dnf install -y make cmake gcc clang meson ninja-build libgit2 libffi-devel
 
 ADD build.sh /root

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```bash
-$ rpm -ivh https://github.com/samber/criterion-rpm-package/releases/download/2.3.3/libcriterion-devel-2.3.3-2.el7.x86_64.rpm
+$ rpm -ivh https://github.com/samber/criterion-rpm-package/releases/download/2.4.0/libcriterion-devel-2.4.0-3.el7.x86_64.rpm
 ```
 
 ## Build package
@@ -27,16 +27,16 @@ gpg --export -a 'contact@samuel-berthe.fr' > /tmp/RPM-GPG-KEY-samber
 rpm --import /tmp/RPM-GPG-KEY-samber
 
 rpm --addsign RPMS/x86_64/libcriterion-devel-*
-rpm --addsign SRPMS/libcriterion-devel-v2.3.3-2.src.rpm
+rpm --addsign SRPMS/libcriterion-devel-v2.4.0-3.src.rpm
 rpm --checksig RPMS/x86_64/libcriterion-devel-*
-rpm --checksig SRPMS/libcriterion-devel-v2.3.3-2.src.rpm
+rpm --checksig SRPMS/libcriterion-devel-v2.4.0-3.src.rpm
 ```
 
 ## Test RPM package
 
 ```
 cd rpmbuild/
-rpm -ivh RPMS/x86_64/libcriterion-devel-v2.3.3-2.x86_64.rpm
+rpm -ivh RPMS/x86_64/libcriterion-devel-v2.4.0-3.x86_64.rpm
 ```
 
 ```
@@ -55,7 +55,8 @@ gcc hello_world.c test_hello_world.c -o test_suite -lcriterion
 
 ```
 cd ./rpmbuild/SOURCES
-wget 'https://github.com/Snaipe/Criterion/releases/download/v2.3.3/criterion-v2.3.3.tar.bz2'
+wget 'https://github.com/Snaipe/Criterion/releases/download/v2.4.0/criterion-2.4.0.tar.xz'
+docker-compose run --rm rpm
 ```
 
 ## Contribute

--- a/rpmbuild/SPECS/libcriterion.spec
+++ b/rpmbuild/SPECS/libcriterion.spec
@@ -1,17 +1,17 @@
 %define projectname criterion
 
 Name:           lib%{projectname}-devel
-Version:        2.3.3
-Release:        2%{?dist}
+Version:        2.4.0
+Release:        3%{?dist}
 Summary:        A cross-platform C and C++ unit testing framework for the 21th century
 Group:          Development/Libraries
 License:        MIT
 URL:            https://github.com/Snaipe/Criterion
 Vendor:         Snaipe
-Source:         https://github.com/Snaipe/Criterion/releases/download/v2.3.3/criterion-v2.3.3.tar.bz2
+Source:         https://github.com/Snaipe/Criterion/releases/download/v2.4.0/criterion-2.4.0.tar.xz
 Prefix:         %{_prefix}
-BuildRoot:      %{_tmppath}/%{name}-v%{version}-root
-BuildRequires:  make, cmake, gcc, clang
+BuildRoot:      %{_tmppath}/%{name}-%{version}-root
+BuildRequires:  make, cmake, gcc, clang, meson, ninja-build, libgit2, libffi-devel
 Requires:       gcc
 
 %description
@@ -44,23 +44,32 @@ Full documentation here: https://criterion.readthedocs.io
 
 %prep
 
-%setup -q -n %{projectname}-v%{version}
+%setup -q -n %{projectname}-%{version}
 
 %build
 
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix} ..
-cmake --build .
+# old build system (up to v2.3.3)
+# mkdir build
+# cd build
+# cmake -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix} ..
+# cmake --build .
+
+# new build system (starting v2.4.0)
+meson build --prefix /usr
+ninja -C build
 
 %install
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
 mkdir -p %{buildroot}
 
-cd build
-make install DESTDIR=%{buildroot}
-mv %{buildroot}%{_prefix}/lib %{buildroot}%{_prefix}/lib64
+# old build system (up to v2.3.3)
+# cd build
+# make install DESTDIR=%{buildroot}
+# mv %{buildroot}%{_prefix}/lib %{buildroot}%{_prefix}/lib64
+
+# new build system (starting v2.4.0)
+meson install -C build/ --destdir %{buildroot}
 
 %clean
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
@@ -74,9 +83,11 @@ mv %{buildroot}%{_prefix}/lib %{buildroot}%{_prefix}/lib64
 %{_includedir}/%{projectname}/*.h
 %{_includedir}/%{projectname}/internal/*.h
 %{_includedir}/%{projectname}/internal/*.hxx
-%{_datarootdir}/pkgconfig/*.pc
+%{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Sat Feb 23 2022 Samuel Berthe <dev@samuel-berthe.fr> v2.4.0-3.samber
+- Upgrade to libcriterion v2.4.0
 * Sat Nov 16 2019 Samuel Berthe <dev@samuel-berthe.fr> v2.3.3-2.samber
 - Upgrade to libcriterion v2.3.3
 * Tue Oct 30 2018 Samuel Berthe <dev@samuel-berthe.fr> v2.3.2-1.samber


### PR DESCRIPTION
WIP

The package is correctly built into `rpmbuild/BUILDROOT` but not released into `rpmbuild/SRPMS` nor `rpmbuild/RPMS`.

I was not able to sign the package and send it into a Github release.

It needs more investigations.

@Sadikum